### PR TITLE
docs(audit): ADR-001 — audit store JSONL file granularity

### DIFF
--- a/docs/adr/001-audit-store-scoping.md
+++ b/docs/adr/001-audit-store-scoping.md
@@ -8,7 +8,7 @@ Phase 1 of Saor uses a JSONL-based audit store (`FileSystemAuditStore`) as the i
 
 This decision affects:
 
-- **Queryability**: How easy it is to find events by time range, by session, or by agent using standard Unix tools (`grep`, `jq`, `cat`).
+- **Queryability**: How easy it is to find events by time range, by session, or by agent using standard Unix tools (`grep`, `jq` (a command-line JSON processor), `cat`).
 - **File count at scale**: How many files accumulate in the audit directory over weeks and months of active development.
 - **UI consumption**: How the audit viewer component loads and displays events.
 - **Single-session replay**: How practical it is to isolate and replay the events from one agent session.


### PR DESCRIPTION
## Summary

Adds ADR-001 documenting the decision to use per-day JSONL files (`YYYY-MM-DD.jsonl`) for the Phase 1 `FileSystemAuditStore`, rather than per-session files. This is a prerequisite decision before audit store implementation begins.

## Changes

- Added `docs/adr/001-audit-store-scoping.md` using the MADR template
- Recommends per-day files with rationale: bounded file count, natural time-range queries, simpler append logic, alignment with the architecture doc's example path
- Documents the trade-off: interleaved sessions require `sessionId` filtering, but this is already handled by the `getBySession()` query method and the `sessionId` field on every `AuditEvent`
- Specifies the file path pattern: `{project}/.sdlc/audit/YYYY-MM-DD.jsonl`

## Testing

No code changes — this is a documentation-only ADR. Verified the file renders correctly in Markdown.

## References

- Closes #1
- Architecture doc: [Section 8.2 — Event Schema](docs/architecture/sdlc-agent-architecture-research-v4.md#82-event-schema)
- Architecture doc: [Section 8.4 — Backend Implementations](docs/architecture/sdlc-agent-architecture-research-v4.md#84-backend-implementations)

## Open Questions

None. The decision is straightforward — per-day is simpler and the `sessionId` field already solves per-session queries. Happy to discuss if you see tradeoffs I've underweighted.

## Checklist

- [x] Follows ADR template (`docs/adr/template.md`)
- [x] Module-level documentation updated (n/a — no code changes)
- [x] PR description references the issue being closed