### PR TITLE
feat(audit): JSONL audit store (#5) + #25 blocking/convergent fixes + protocol findings

### DIFF
--- a/src-tauri/src/audit/mod.rs
+++ b/src-tauri/src/audit/mod.rs
@@ -5,13 +5,16 @@
 // decisions. The audit trail is populated automatically by hooks — agents
 // do not opt in or out of auditing.
 //
-// Phase 1 uses JSONL files (one per day or per session — see ADR when
-// written) for human-readability and debuggability. A SQLite-backed
-// implementation can be substituted later without changing the interface
-// or the hook layer that writes to it.
+// Phase 1 uses per-day JSONL files (ADR-001) for human-readability and
+// debuggability. A SQLite-backed implementation can be substituted later
+// without changing the interface or the hook layer that writes to it.
 //
 // See docs/architecture/sdlc-agent-architecture-research-v4.md Section 8
 // for the audit trail design, event schema, and abstraction interface.
 
 pub mod schema;
 pub mod store;
+
+// Re-export the public API for ergonomic imports.
+pub use schema::{AuditError, AuditEvent, AuditEventType, AuditResult};
+pub use store::FileSystemAuditStore;

--- a/src-tauri/src/audit/schema.rs
+++ b/src-tauri/src/audit/schema.rs
@@ -29,6 +29,26 @@ pub enum AuditError {
     DirectoryCreation(String),
 }
 
+/// Record of a JSONL line that could not be deserialised into an
+/// AuditEvent — partial write at crash, manual edit, mixed-version
+/// schema. The audit store's read path log-and-skips these so a single
+/// bad line doesn't abort the whole query, but the records are
+/// returned alongside the events so callers (audit viewer UI, hook
+/// layer, tests) can surface or count corruption deliberately.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MalformedLine {
+    /// Path to the JSONL file containing the malformed line.
+    pub file: std::path::PathBuf,
+
+    /// 1-indexed line number within the file (user-facing convention).
+    pub line_number: usize,
+
+    /// `serde_json::Error::Display` for diagnostics. The raw line
+    /// content is intentionally not captured here — a tampered file
+    /// could otherwise leak content via this string.
+    pub error: String,
+}
+
 /// Exhaustive set of audit event types. Each variant maps to a dot-notation
 /// string (e.g., `AgentCreated` serializes to `"agent.created"`) for
 /// consistency with the TypeScript interface.

--- a/src-tauri/src/audit/schema.rs
+++ b/src-tauri/src/audit/schema.rs
@@ -7,9 +7,241 @@
 //
 // AuditEventType is an exhaustive enum covering lifecycle events
 // (agent.created, agent.completed), action events (tool.invoked,
-// file.write), and security events (scope.violation, credential.expired).
+// file.write), decision events (decision.routing, handoff.initiated),
+// and security events (scope.violation, credential.expired).
 //
 // See docs/architecture/sdlc-agent-architecture-research-v4.md Section 8.2
 // for the full event schema with field-level documentation.
 
-// Implementation coming in Phase 1 audit store work.
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors that can occur in audit store operations.
+#[derive(Debug, Error)]
+pub enum AuditError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("failed to create audit directory: {0}")]
+    DirectoryCreation(String),
+}
+
+/// Exhaustive set of audit event types. Each variant maps to a dot-notation
+/// string (e.g., `AgentCreated` serializes to `"agent.created"`) for
+/// consistency with the TypeScript interface.
+///
+/// Categories:
+/// - Lifecycle: agent creation, completion, failure, expiration
+/// - Actions: tool invocations, file operations, issue tracking, memory access
+/// - Decisions: routing, approvals, rejections, handoffs
+/// - Security: scope violations, credential expiry, auth failures
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum AuditEventType {
+    // Lifecycle events
+    #[serde(rename = "agent.created")]
+    AgentCreated,
+    #[serde(rename = "agent.completed")]
+    AgentCompleted,
+    #[serde(rename = "agent.failed")]
+    AgentFailed,
+    #[serde(rename = "agent.expired")]
+    AgentExpired,
+
+    // Action events
+    #[serde(rename = "tool.invoked")]
+    ToolInvoked,
+    #[serde(rename = "tool.completed")]
+    ToolCompleted,
+    #[serde(rename = "tool.blocked")]
+    ToolBlocked,
+    #[serde(rename = "file.read")]
+    FileRead,
+    #[serde(rename = "file.write")]
+    FileWrite,
+    #[serde(rename = "file.delete")]
+    FileDelete,
+    #[serde(rename = "issue.created")]
+    IssueCreated,
+    #[serde(rename = "issue.updated")]
+    IssueUpdated,
+    #[serde(rename = "issue.closed")]
+    IssueClosed,
+    #[serde(rename = "memory.read")]
+    MemoryRead,
+    #[serde(rename = "memory.write")]
+    MemoryWrite,
+
+    // Decision events
+    #[serde(rename = "decision.routing")]
+    DecisionRouting,
+    #[serde(rename = "decision.approval")]
+    DecisionApproval,
+    #[serde(rename = "decision.rejection")]
+    DecisionRejection,
+    #[serde(rename = "handoff.initiated")]
+    HandoffInitiated,
+    #[serde(rename = "handoff.completed")]
+    HandoffCompleted,
+
+    // Security events
+    #[serde(rename = "scope.violation")]
+    ScopeViolation,
+    #[serde(rename = "credential.expired")]
+    CredentialExpired,
+    #[serde(rename = "auth.failed")]
+    AuthFailed,
+}
+
+/// Outcome of an audited action.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuditResult {
+    Success,
+    Failure,
+    Blocked,
+    Pending,
+}
+
+/// A single audit event capturing an agent action, decision, or lifecycle
+/// transition. Every field uses camelCase serialization to match the
+/// TypeScript interface.
+///
+/// The audit trail is append-only — events are never modified or deleted.
+/// They are written automatically by hooks (PostToolUse, PreToolUse) and
+/// queried by the audit viewer UI and by agents (e.g., Documentation
+/// Specialist generating changelogs).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEvent {
+    /// Unique event identifier (UUID v4).
+    pub id: String,
+
+    /// ISO 8601 timestamp of when the event occurred.
+    pub timestamp: String,
+
+    /// Project this event belongs to.
+    pub project_id: String,
+
+    /// Identity ID of the agent that performed the action.
+    pub agent_id: String,
+
+    /// Role of the agent (e.g., "code-agent", "pm-coordinator").
+    pub agent_role: String,
+
+    /// Full delegation chain from this agent back to the human.
+    pub delegation_chain: Vec<String>,
+
+    /// Type of event — categorizes what happened.
+    pub event_type: AuditEventType,
+
+    /// Human-readable description of the action.
+    pub action: String,
+
+    /// Structured details — tool parameters, file paths, metadata.
+    pub details: serde_json::Value,
+
+    /// Issue tracker reference (e.g., "PROJ-167"). Optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_ref: Option<String>,
+
+    /// Initiative tracker reference (e.g., "PROJ-100"). Optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initiative_ref: Option<String>,
+
+    /// Claude SDK session ID for grouping events from the same session.
+    pub session_id: String,
+
+    /// Outcome of the action.
+    pub result: AuditResult,
+
+    /// Explanation, especially for blocked or failed actions. Optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_type_serializes_to_dot_notation() {
+        assert_eq!(
+            serde_json::to_string(&AuditEventType::AgentCreated).unwrap(),
+            "\"agent.created\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuditEventType::ToolBlocked).unwrap(),
+            "\"tool.blocked\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuditEventType::ScopeViolation).unwrap(),
+            "\"scope.violation\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuditEventType::HandoffCompleted).unwrap(),
+            "\"handoff.completed\""
+        );
+    }
+
+    #[test]
+    fn test_event_type_deserializes_from_dot_notation() {
+        let parsed: AuditEventType = serde_json::from_str("\"tool.invoked\"").unwrap();
+        assert_eq!(parsed, AuditEventType::ToolInvoked);
+
+        let parsed: AuditEventType = serde_json::from_str("\"scope.violation\"").unwrap();
+        assert_eq!(parsed, AuditEventType::ScopeViolation);
+    }
+
+    #[test]
+    fn test_audit_result_serializes_to_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&AuditResult::Success).unwrap(),
+            "\"success\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuditResult::Blocked).unwrap(),
+            "\"blocked\""
+        );
+    }
+
+    #[test]
+    fn test_audit_event_uses_camel_case_field_names() {
+        let event = AuditEvent {
+            id: "evt-001".to_string(),
+            timestamp: "2026-02-25T12:00:00Z".to_string(),
+            project_id: "proj-1".to_string(),
+            agent_id: "agent:code:auth".to_string(),
+            agent_role: "code-agent".to_string(),
+            delegation_chain: vec!["human:kevin".to_string()],
+            event_type: AuditEventType::ToolInvoked,
+            action: "Read file src/main.rs".to_string(),
+            details: serde_json::json!({"path": "src/main.rs"}),
+            issue_ref: Some("PROJ-167".to_string()),
+            initiative_ref: None,
+            session_id: "session-abc".to_string(),
+            result: AuditResult::Success,
+            reason: None,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+
+        // Verify camelCase field names.
+        assert!(json.contains("\"projectId\""));
+        assert!(json.contains("\"agentId\""));
+        assert!(json.contains("\"agentRole\""));
+        assert!(json.contains("\"delegationChain\""));
+        assert!(json.contains("\"eventType\""));
+        assert!(json.contains("\"issueRef\""));
+        assert!(json.contains("\"sessionId\""));
+
+        // Verify dot-notation event type.
+        assert!(json.contains("\"tool.invoked\""));
+
+        // Verify optional None fields are omitted.
+        assert!(!json.contains("\"initiativeRef\""));
+        assert!(!json.contains("\"reason\""));
+    }
+}

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 
-use super::schema::{AuditError, AuditEvent, AuditEventType};
+use super::schema::{AuditError, AuditEvent, AuditEventType, MalformedLine};
 
 /// Append-only JSONL audit store. Writes events to per-day files under
 /// `{project_path}/.sdlc/audit/` following the granularity strategy
@@ -31,7 +31,9 @@ use super::schema::{AuditError, AuditEvent, AuditEventType};
 ///
 /// Each call to `log()` appends a single JSON line to today's file.
 /// Query methods read all files and filter in memory — acceptable for
-/// Phase 1 scale.
+/// Phase 1 scale (expect tens of MB of audit history before the
+/// SqliteAuditStore migration becomes warranted; see Phase 4 in
+/// architecture Section 8.4).
 pub struct FileSystemAuditStore {
     audit_dir: PathBuf,
 }
@@ -77,7 +79,7 @@ impl FileSystemAuditStore {
 
     /// Returns all events from a specific session, across all audit files.
     pub fn get_by_session(&self, session_id: &str) -> Result<Vec<AuditEvent>, AuditError> {
-        let events = self.read_all_events()?;
+        let (events, _malformed) = self.read_all_events()?;
         Ok(events
             .into_iter()
             .filter(|e| e.session_id == session_id)
@@ -86,7 +88,7 @@ impl FileSystemAuditStore {
 
     /// Returns all events from a specific agent, across all audit files.
     pub fn get_by_agent(&self, agent_id: &str) -> Result<Vec<AuditEvent>, AuditError> {
-        let events = self.read_all_events()?;
+        let (events, _malformed) = self.read_all_events()?;
         Ok(events
             .into_iter()
             .filter(|e| e.agent_id == agent_id)
@@ -98,7 +100,7 @@ impl FileSystemAuditStore {
         &self,
         event_type: &AuditEventType,
     ) -> Result<Vec<AuditEvent>, AuditError> {
-        let events = self.read_all_events()?;
+        let (events, _malformed) = self.read_all_events()?;
         Ok(events
             .into_iter()
             .filter(|e| &e.event_type == event_type)
@@ -113,17 +115,51 @@ impl FileSystemAuditStore {
     /// Architecture Section 8.3 lists `getByIssue` as part of the
     /// `AuditStore` interface; this method implements it.
     pub fn get_by_issue(&self, issue_ref: &str) -> Result<Vec<AuditEvent>, AuditError> {
-        let events = self.read_all_events()?;
+        let (events, _malformed) = self.read_all_events()?;
         Ok(events
             .into_iter()
             .filter(|e| e.issue_ref.as_deref() == Some(issue_ref))
             .collect())
     }
 
+    /// Returns the list of malformed JSONL lines encountered when
+    /// reading the audit history. Each record carries the file path,
+    /// 1-indexed line number, and parse-error string so callers (audit
+    /// viewer, hook layer, tests) can surface or count corruption
+    /// deliberately rather than silently absorbing it.
+    ///
+    /// Empty result means the on-disk audit history was clean as of
+    /// the call. The same lines are reported on every call — there is
+    /// no de-duplication or rate-limiting; the caller decides what to
+    /// do with the information.
+    pub fn corruption_report(&self) -> Result<Vec<MalformedLine>, AuditError> {
+        let (_events, malformed) = self.read_all_events()?;
+        Ok(malformed)
+    }
+
     /// Reads all JSONL files in the audit directory, sorted by filename
     /// (which sorts chronologically due to YYYY-MM-DD naming), and
-    /// deserializes every line into an AuditEvent.
-    fn read_all_events(&self) -> Result<Vec<AuditEvent>, AuditError> {
+    /// deserialises every line into an AuditEvent.
+    ///
+    /// Returns the events in chronological-by-filename order plus a
+    /// list of malformed lines that were skipped. Audit data is
+    /// forensic, so a single corrupt line (partial write at crash,
+    /// disk corruption, manual edit, mixed-version schema) is reported
+    /// rather than aborting the whole query — JSONL is designed to
+    /// tolerate per-line failures. The `MalformedLine` records carry
+    /// enough context (file path, 1-indexed line number, parse error)
+    /// for the caller to surface corruption to a human; the raw line
+    /// content is deliberately not captured to avoid leaking tampered
+    /// payloads.
+    ///
+    /// TODO(phase-4): this read path scans every JSONL file and holds
+    /// the full deserialised history in memory. Acceptable while audit
+    /// volume is bounded (Phase 1 expects on the order of tens of MB).
+    /// SqliteAuditStore — the Phase 4 upgrade per architecture Section
+    /// 8.4 — replaces this with indexed queries and is the planned
+    /// answer to the scaling concern, not an in-place optimisation
+    /// here.
+    fn read_all_events(&self) -> Result<(Vec<AuditEvent>, Vec<MalformedLine>), AuditError> {
         let mut files: Vec<PathBuf> = fs::read_dir(&self.audit_dir)?
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.path())
@@ -134,39 +170,32 @@ impl FileSystemAuditStore {
         files.sort();
 
         let mut events = Vec::new();
+        let mut malformed = Vec::new();
         for file_path in files {
             let file = fs::File::open(&file_path)?;
             let reader = BufReader::new(file);
 
-            for (line_number, line) in reader.lines().enumerate() {
+            for (line_index, line) in reader.lines().enumerate() {
                 let line = line?;
                 if line.trim().is_empty() {
                     continue;
                 }
-                // Log-and-skip malformed lines rather than aborting the
-                // entire query. Audit data is forensic — failing closed
-                // on a single corrupt line (partial write at crash,
-                // disk corruption, manual edit, mixed-version schema)
-                // would hide every prior event from queries. JSONL is
-                // designed to tolerate per-line failures. eprintln! is
-                // a placeholder until structured logging lands.
                 match serde_json::from_str::<AuditEvent>(&line) {
                     Ok(event) => events.push(event),
                     Err(err) => {
-                        eprintln!(
-                            "audit: skipping malformed line {} in {}: {}",
-                            // line_number is 0-indexed; user-facing
+                        malformed.push(MalformedLine {
+                            file: file_path.clone(),
+                            // line_index is 0-indexed; user-facing
                             // convention is 1-indexed.
-                            line_number + 1,
-                            file_path.display(),
-                            err
-                        );
+                            line_number: line_index + 1,
+                            error: err.to_string(),
+                        });
                     }
                 }
             }
         }
 
-        Ok(events)
+        Ok((events, malformed))
     }
 }
 
@@ -457,15 +486,14 @@ mod tests {
         // today's file. The malformed line is bracketed by valid events
         // so we can verify the iteration recovers.
         let today_filename = format!("{}.jsonl", Utc::now().format("%Y-%m-%d"));
-        let today_path = tmp.path().join(".sdlc").join("audit").join(today_filename);
+        let today_path = tmp.path().join(".sdlc").join("audit").join(&today_filename);
 
-        let mut event_after = test_event(
+        let event_after = test_event(
             "evt-valid-2",
             "session-1",
             "agent-1",
             AuditEventType::FileWrite,
         );
-        event_after.id = "evt-valid-2".to_string();
         let valid_after_json = serde_json::to_string(&event_after).unwrap();
 
         let mut file = OpenOptions::new()
@@ -483,6 +511,52 @@ mod tests {
         assert_eq!(events.len(), 2, "expected two valid events, malformed line skipped");
         assert_eq!(events[0].id, "evt-valid-1");
         assert_eq!(events[1].id, "evt-valid-2");
+
+        // The corruption_report API surfaces the skipped line to
+        // callers so they can act on it (e.g., audit viewer UI flag,
+        // structured logging when it lands). The previous evt-valid-1
+        // is on line 1; the malformed line is line 2.
+        let report = store.corruption_report().unwrap();
+        assert_eq!(report.len(), 1, "expected exactly one malformed line");
+        assert_eq!(report[0].line_number, 2);
+        assert_eq!(report[0].file, today_path);
+        // The error message must not be empty — we want a diagnostic
+        // string available to callers — but we don't pin its exact
+        // contents because serde_json's wording can change.
+        assert!(
+            !report[0].error.is_empty(),
+            "expected a non-empty parse-error message"
+        );
+    }
+
+    #[test]
+    fn test_corruption_report_is_empty_when_audit_history_is_clean() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        // No events logged — reading an empty audit dir yields no
+        // events and no malformed lines.
+        assert!(store.corruption_report().unwrap().is_empty());
+
+        // After well-formed writes the corruption report stays empty.
+        store
+            .log(&test_event(
+                "evt-1",
+                "session-1",
+                "agent-1",
+                AuditEventType::FileWrite,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-2",
+                "session-1",
+                "agent-1",
+                AuditEventType::FileWrite,
+            ))
+            .unwrap();
+
+        assert!(store.corruption_report().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -50,9 +50,16 @@ impl FileSystemAuditStore {
     /// Appends a single audit event as a JSON line to today's file.
     ///
     /// The file is created if it doesn't exist. Each event is a single
-    /// line — no multi-line records. The file is opened in append mode
-    /// so concurrent calls within the same process are safe (though
-    /// Phase 1 runs a single agent at a time).
+    /// line — no multi-line records.
+    ///
+    /// Concurrency: Phase 1 runs a single agent at a time, so this
+    /// method does not implement explicit serialization. POSIX `O_APPEND`
+    /// makes a single `write()` call atomic only up to `PIPE_BUF`
+    /// (~4 KiB on most systems), and `writeln!` may issue multiple
+    /// writes for a large event — so concurrent multi-process callers
+    /// could interleave a single event's bytes. Adding a `Mutex<File>`
+    /// or a single `write_all` of a pre-built buffer is deferred until
+    /// concurrent agents become a real Phase 2 requirement.
     pub fn log(&self, event: &AuditEvent) -> Result<(), AuditError> {
         let filename = format!("{}.jsonl", Utc::now().format("%Y-%m-%d"));
         let file_path = self.audit_dir.join(filename);
@@ -98,6 +105,21 @@ impl FileSystemAuditStore {
             .collect())
     }
 
+    /// Returns all events tied to a specific issue reference (e.g.,
+    /// `"PROJ-167"`), across all audit files. Events with no
+    /// `issue_ref` are excluded — the filter is exact-match against
+    /// `Some(issue_ref)`.
+    ///
+    /// Architecture Section 8.3 lists `getByIssue` as part of the
+    /// `AuditStore` interface; this method implements it.
+    pub fn get_by_issue(&self, issue_ref: &str) -> Result<Vec<AuditEvent>, AuditError> {
+        let events = self.read_all_events()?;
+        Ok(events
+            .into_iter()
+            .filter(|e| e.issue_ref.as_deref() == Some(issue_ref))
+            .collect())
+    }
+
     /// Reads all JSONL files in the audit directory, sorted by filename
     /// (which sorts chronologically due to YYYY-MM-DD naming), and
     /// deserializes every line into an AuditEvent.
@@ -116,13 +138,31 @@ impl FileSystemAuditStore {
             let file = fs::File::open(&file_path)?;
             let reader = BufReader::new(file);
 
-            for line in reader.lines() {
+            for (line_number, line) in reader.lines().enumerate() {
                 let line = line?;
                 if line.trim().is_empty() {
                     continue;
                 }
-                let event: AuditEvent = serde_json::from_str(&line)?;
-                events.push(event);
+                // Log-and-skip malformed lines rather than aborting the
+                // entire query. Audit data is forensic — failing closed
+                // on a single corrupt line (partial write at crash,
+                // disk corruption, manual edit, mixed-version schema)
+                // would hide every prior event from queries. JSONL is
+                // designed to tolerate per-line failures. eprintln! is
+                // a placeholder until structured logging lands.
+                match serde_json::from_str::<AuditEvent>(&line) {
+                    Ok(event) => events.push(event),
+                    Err(err) => {
+                        eprintln!(
+                            "audit: skipping malformed line {} in {}: {}",
+                            // line_number is 0-indexed; user-facing
+                            // convention is 1-indexed.
+                            line_number + 1,
+                            file_path.display(),
+                            err
+                        );
+                    }
+                }
             }
         }
 
@@ -320,6 +360,129 @@ mod tests {
         assert_eq!(violations.len(), 2);
         assert_eq!(violations[0].id, "evt-1");
         assert_eq!(violations[1].id, "evt-3");
+    }
+
+    #[test]
+    fn test_get_by_issue_filters_to_matching_issue_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        let mut event_a = test_event(
+            "evt-a",
+            "session-1",
+            "agent-1",
+            AuditEventType::FileWrite,
+        );
+        event_a.issue_ref = Some("PROJ-167".to_string());
+
+        let mut event_b = test_event(
+            "evt-b",
+            "session-1",
+            "agent-1",
+            AuditEventType::FileWrite,
+        );
+        event_b.issue_ref = Some("PROJ-200".to_string());
+
+        let mut event_c = test_event(
+            "evt-c",
+            "session-1",
+            "agent-1",
+            AuditEventType::FileWrite,
+        );
+        event_c.issue_ref = Some("PROJ-167".to_string());
+
+        store.log(&event_a).unwrap();
+        store.log(&event_b).unwrap();
+        store.log(&event_c).unwrap();
+
+        let proj_167 = store.get_by_issue("PROJ-167").unwrap();
+        assert_eq!(proj_167.len(), 2);
+        assert_eq!(proj_167[0].id, "evt-a");
+        assert_eq!(proj_167[1].id, "evt-c");
+
+        let proj_200 = store.get_by_issue("PROJ-200").unwrap();
+        assert_eq!(proj_200.len(), 1);
+        assert_eq!(proj_200[0].id, "evt-b");
+    }
+
+    #[test]
+    fn test_get_by_issue_excludes_events_with_no_issue_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        // test_event sets issue_ref to None by default.
+        store
+            .log(&test_event(
+                "evt-no-issue",
+                "session-1",
+                "agent-1",
+                AuditEventType::FileWrite,
+            ))
+            .unwrap();
+
+        let mut event_with_issue = test_event(
+            "evt-with-issue",
+            "session-1",
+            "agent-1",
+            AuditEventType::FileWrite,
+        );
+        event_with_issue.issue_ref = Some("PROJ-167".to_string());
+        store.log(&event_with_issue).unwrap();
+
+        let results = store.get_by_issue("PROJ-167").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "evt-with-issue");
+
+        // An empty issue_ref string should not match the None event.
+        let empty = store.get_by_issue("").unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_read_all_events_skips_malformed_jsonl_lines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        // Write one valid event so the file exists.
+        store
+            .log(&test_event(
+                "evt-valid-1",
+                "session-1",
+                "agent-1",
+                AuditEventType::FileWrite,
+            ))
+            .unwrap();
+
+        // Append a malformed line and another valid event directly to
+        // today's file. The malformed line is bracketed by valid events
+        // so we can verify the iteration recovers.
+        let today_filename = format!("{}.jsonl", Utc::now().format("%Y-%m-%d"));
+        let today_path = tmp.path().join(".sdlc").join("audit").join(today_filename);
+
+        let mut event_after = test_event(
+            "evt-valid-2",
+            "session-1",
+            "agent-1",
+            AuditEventType::FileWrite,
+        );
+        event_after.id = "evt-valid-2".to_string();
+        let valid_after_json = serde_json::to_string(&event_after).unwrap();
+
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(&today_path)
+            .unwrap();
+        writeln!(file, "{{this is not valid json").unwrap();
+        writeln!(file, "{valid_after_json}").unwrap();
+        drop(file);
+
+        // The query must succeed, returning the two valid events and
+        // skipping the malformed line. A pre-fix version of the store
+        // would propagate the serde error and return Err.
+        let events = store.get_by_session("session-1").unwrap();
+        assert_eq!(events.len(), 2, "expected two valid events, malformed line skipped");
+        assert_eq!(events[0].id, "evt-valid-1");
+        assert_eq!(events[1].id, "evt-valid-2");
     }
 
     #[test]

--- a/src-tauri/src/audit/store.rs
+++ b/src-tauri/src/audit/store.rs
@@ -2,16 +2,364 @@
 //
 // FileSystemAuditStore — the Phase 1 implementation of the audit store,
 // writing append-only JSONL files. Each line is a serialized AuditEvent.
-// The store supports basic query operations (by agent, by issue, by session)
-// by reading and filtering the JSONL files. For Phase 1 project scale,
-// this is fast enough; for larger audit histories, the SqliteAuditStore
-// will take over without changing the calling code.
+// The store supports basic query operations (by agent, by session, by
+// event type) by reading and filtering the JSONL files.
 //
-// JSONL files are written to {project_path}/.sdlc/audit/. The file naming
-// granularity (per-day vs per-session) is determined by the ADR for this
-// module.
+// File naming follows ADR-001: one JSONL file per calendar day, named
+// YYYY-MM-DD.jsonl. All sessions on the same day write to the same file,
+// with events interleaved chronologically. The sessionId field on each
+// event enables per-session filtering.
+//
+// JSONL files are written to {project_path}/.sdlc/audit/. For Phase 1
+// project scale, full-file scans are fast enough. The SqliteAuditStore
+// upgrade path (Phase 4+) will take over without changing the hook layer.
 //
 // See docs/architecture/sdlc-agent-architecture-research-v4.md Section 8.4
 // for the FileSystemAuditStore design and the SqliteAuditStore upgrade path.
 
-// Implementation coming in Phase 1 audit store work.
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+
+use super::schema::{AuditError, AuditEvent, AuditEventType};
+
+/// Append-only JSONL audit store. Writes events to per-day files under
+/// `{project_path}/.sdlc/audit/` following the granularity strategy
+/// from ADR-001.
+///
+/// Each call to `log()` appends a single JSON line to today's file.
+/// Query methods read all files and filter in memory — acceptable for
+/// Phase 1 scale.
+pub struct FileSystemAuditStore {
+    audit_dir: PathBuf,
+}
+
+impl FileSystemAuditStore {
+    /// Creates a new audit store rooted at `{project_path}/.sdlc/audit/`.
+    /// Creates the directory if it doesn't exist.
+    pub fn new(project_path: &Path) -> Result<Self, AuditError> {
+        let audit_dir = project_path.join(".sdlc").join("audit");
+        fs::create_dir_all(&audit_dir).map_err(|e| {
+            AuditError::DirectoryCreation(format!("failed to create {}: {e}", audit_dir.display()))
+        })?;
+        Ok(Self { audit_dir })
+    }
+
+    /// Appends a single audit event as a JSON line to today's file.
+    ///
+    /// The file is created if it doesn't exist. Each event is a single
+    /// line — no multi-line records. The file is opened in append mode
+    /// so concurrent calls within the same process are safe (though
+    /// Phase 1 runs a single agent at a time).
+    pub fn log(&self, event: &AuditEvent) -> Result<(), AuditError> {
+        let filename = format!("{}.jsonl", Utc::now().format("%Y-%m-%d"));
+        let file_path = self.audit_dir.join(filename);
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file_path)?;
+
+        let json = serde_json::to_string(event)?;
+        writeln!(file, "{json}")?;
+
+        Ok(())
+    }
+
+    /// Returns all events from a specific session, across all audit files.
+    pub fn get_by_session(&self, session_id: &str) -> Result<Vec<AuditEvent>, AuditError> {
+        let events = self.read_all_events()?;
+        Ok(events
+            .into_iter()
+            .filter(|e| e.session_id == session_id)
+            .collect())
+    }
+
+    /// Returns all events from a specific agent, across all audit files.
+    pub fn get_by_agent(&self, agent_id: &str) -> Result<Vec<AuditEvent>, AuditError> {
+        let events = self.read_all_events()?;
+        Ok(events
+            .into_iter()
+            .filter(|e| e.agent_id == agent_id)
+            .collect())
+    }
+
+    /// Returns all events of a specific type, across all audit files.
+    pub fn get_by_event_type(
+        &self,
+        event_type: &AuditEventType,
+    ) -> Result<Vec<AuditEvent>, AuditError> {
+        let events = self.read_all_events()?;
+        Ok(events
+            .into_iter()
+            .filter(|e| &e.event_type == event_type)
+            .collect())
+    }
+
+    /// Reads all JSONL files in the audit directory, sorted by filename
+    /// (which sorts chronologically due to YYYY-MM-DD naming), and
+    /// deserializes every line into an AuditEvent.
+    fn read_all_events(&self) -> Result<Vec<AuditEvent>, AuditError> {
+        let mut files: Vec<PathBuf> = fs::read_dir(&self.audit_dir)?
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().map(|ext| ext == "jsonl").unwrap_or(false))
+            .collect();
+
+        // Sort by filename for chronological order.
+        files.sort();
+
+        let mut events = Vec::new();
+        for file_path in files {
+            let file = fs::File::open(&file_path)?;
+            let reader = BufReader::new(file);
+
+            for line in reader.lines() {
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let event: AuditEvent = serde_json::from_str(&line)?;
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::schema::AuditResult;
+    use super::*;
+
+    /// Helper to create a test audit event with configurable fields.
+    fn test_event(
+        id: &str,
+        session_id: &str,
+        agent_id: &str,
+        event_type: AuditEventType,
+    ) -> AuditEvent {
+        AuditEvent {
+            id: id.to_string(),
+            timestamp: "2026-02-25T12:00:00Z".to_string(),
+            project_id: "test-project".to_string(),
+            agent_id: agent_id.to_string(),
+            agent_role: "code-agent".to_string(),
+            delegation_chain: vec!["human:kevin".to_string()],
+            event_type,
+            action: format!("Test action for {id}"),
+            details: serde_json::json!({"test": true}),
+            issue_ref: None,
+            initiative_ref: None,
+            session_id: session_id.to_string(),
+            result: AuditResult::Success,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn test_log_creates_file_and_appends_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+        let event = test_event("evt-1", "session-1", "agent-1", AuditEventType::ToolInvoked);
+
+        store.log(&event).unwrap();
+
+        // Verify the audit directory contains exactly one .jsonl file.
+        let files: Vec<_> = fs::read_dir(tmp.path().join(".sdlc").join("audit"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(files.len(), 1);
+
+        // Verify the file name matches today's date.
+        let filename = files[0].file_name().to_string_lossy().to_string();
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        assert_eq!(filename, format!("{today}.jsonl"));
+
+        // Verify the event can be read back.
+        let events = store.get_by_session("session-1").unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "evt-1");
+    }
+
+    #[test]
+    fn test_log_multiple_events_preserves_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        for i in 0..3 {
+            let event = test_event(
+                &format!("evt-{i}"),
+                "session-1",
+                "agent-1",
+                AuditEventType::ToolInvoked,
+            );
+            store.log(&event).unwrap();
+        }
+
+        let events = store.get_by_session("session-1").unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].id, "evt-0");
+        assert_eq!(events[1].id, "evt-1");
+        assert_eq!(events[2].id, "evt-2");
+    }
+
+    #[test]
+    fn test_get_by_session_filters_correctly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        store
+            .log(&test_event(
+                "evt-a1",
+                "session-a",
+                "agent-1",
+                AuditEventType::ToolInvoked,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-b1",
+                "session-b",
+                "agent-1",
+                AuditEventType::FileWrite,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-a2",
+                "session-a",
+                "agent-1",
+                AuditEventType::ToolCompleted,
+            ))
+            .unwrap();
+
+        let session_a = store.get_by_session("session-a").unwrap();
+        assert_eq!(session_a.len(), 2);
+        assert_eq!(session_a[0].id, "evt-a1");
+        assert_eq!(session_a[1].id, "evt-a2");
+
+        let session_b = store.get_by_session("session-b").unwrap();
+        assert_eq!(session_b.len(), 1);
+        assert_eq!(session_b[0].id, "evt-b1");
+    }
+
+    #[test]
+    fn test_get_by_agent_filters_correctly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        store
+            .log(&test_event(
+                "evt-1",
+                "session-1",
+                "agent:code:auth",
+                AuditEventType::FileRead,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-2",
+                "session-1",
+                "agent:test:auth",
+                AuditEventType::ToolInvoked,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-3",
+                "session-1",
+                "agent:code:auth",
+                AuditEventType::FileWrite,
+            ))
+            .unwrap();
+
+        let code_agent = store.get_by_agent("agent:code:auth").unwrap();
+        assert_eq!(code_agent.len(), 2);
+        assert_eq!(code_agent[0].id, "evt-1");
+        assert_eq!(code_agent[1].id, "evt-3");
+    }
+
+    #[test]
+    fn test_get_by_event_type_filters_correctly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FileSystemAuditStore::new(tmp.path()).unwrap();
+
+        store
+            .log(&test_event(
+                "evt-1",
+                "session-1",
+                "agent-1",
+                AuditEventType::ScopeViolation,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-2",
+                "session-1",
+                "agent-1",
+                AuditEventType::ToolInvoked,
+            ))
+            .unwrap();
+        store
+            .log(&test_event(
+                "evt-3",
+                "session-1",
+                "agent-1",
+                AuditEventType::ScopeViolation,
+            ))
+            .unwrap();
+
+        let violations = store
+            .get_by_event_type(&AuditEventType::ScopeViolation)
+            .unwrap();
+        assert_eq!(violations.len(), 2);
+        assert_eq!(violations[0].id, "evt-1");
+        assert_eq!(violations[1].id, "evt-3");
+    }
+
+    #[test]
+    fn test_event_serialization_round_trip() {
+        let event = AuditEvent {
+            id: "evt-rt".to_string(),
+            timestamp: "2026-02-25T12:00:00Z".to_string(),
+            project_id: "proj-1".to_string(),
+            agent_id: "agent:code:auth-module:sprint-42".to_string(),
+            agent_role: "code-agent".to_string(),
+            delegation_chain: vec![
+                "human:kevin".to_string(),
+                "agent:pm-coordinator:proj-100".to_string(),
+            ],
+            event_type: AuditEventType::ScopeViolation,
+            action: "Attempted write to /config/secrets.env".to_string(),
+            details: serde_json::json!({
+                "file": "/config/secrets.env",
+                "scope": ["src/**", "tests/**"]
+            }),
+            issue_ref: Some("PROJ-167".to_string()),
+            initiative_ref: Some("PROJ-100".to_string()),
+            session_id: "session-xyz".to_string(),
+            result: AuditResult::Blocked,
+            reason: Some("File not in agent scope: [src/**, tests/**]".to_string()),
+        };
+
+        // Serialize to JSON line.
+        let json = serde_json::to_string(&event).unwrap();
+
+        // Deserialize back.
+        let parsed: AuditEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.id, event.id);
+        assert_eq!(parsed.agent_id, event.agent_id);
+        assert_eq!(parsed.event_type, event.event_type);
+        assert_eq!(parsed.result, event.result);
+        assert_eq!(parsed.reason, event.reason);
+        assert_eq!(parsed.delegation_chain.len(), 2);
+        assert_eq!(parsed.issue_ref, Some("PROJ-167".to_string()));
+        assert_eq!(parsed.initiative_ref, Some("PROJ-100".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the JSONL audit store per architecture Section 8 and ADR-001 (per-day file granularity), satisfying the Phase 1 audit layer requirement (#5). Folds in the blocking + convergent dry-run findings from #25 in commit 2, and the convergent findings from running the review-assistance protocol on the post-fix branch in commit 3. Suggestions and nits stay open in #25 for follow-up per the agreed scope.

## Changes

**Commit 1 — `feat(audit): implement JSONL audit store`** (cherry-picked from the original bundled `4/memory-audit-stores` branch, with no modifications):

- `AuditEvent`, `AuditEventType` (23 variants), `AuditResult` types in `schema.rs` with serde camelCase / dot-notation serialisation
- `FileSystemAuditStore` writes per-day JSONL files at `{project}/.sdlc/audit/YYYY-MM-DD.jsonl` per [ADR-001](docs/adr/001-audit-store-scoping.md)
- `log` (append), `get_by_session`, `get_by_agent`, `get_by_event_type` query methods
- `AuditError` via `thiserror`

**Commit 2 — `test(audit): address #25 blocking + convergent dry-run findings`**:

*Blocking — `AuditStore::getByIssue` was missing entirely:*
- Implement `get_by_issue(issue_ref)` filtering by exact match against `Some(issue_ref)`. Architecture Section 8.3 lists this as part of the interface.
- Tests: `test_get_by_issue_filters_to_matching_issue_ref`, `test_get_by_issue_excludes_events_with_no_issue_ref`.

*Convergent — single corrupt JSONL line aborts every audit query:*
- `read_all_events` log-and-skips malformed lines instead of propagating the serde error.
- Test: `test_read_all_events_skips_malformed_jsonl_lines` writes a malformed line between two valid events and asserts the query recovers.

*Convergent — `log()` doc comment overstates concurrent-append safety:*
- Tighten the wording: explicitly note POSIX `O_APPEND` is atomic only up to `PIPE_BUF` (~4 KiB) and that `writeln!` may issue multiple writes for large events. Defer `Mutex<File>` / single-buffer `write_all` to Phase 2 when concurrent agents become a real requirement.

**Commit 3 — `fix(audit): address protocol findings on the audit branch`**:

After commit 2, `/review-branch` was run on `5/jsonl-audit-store` and surfaced three convergent concerns. Kevin reviewed the synthesis and approved three inline fixes:

*Convergent — `eprintln!` log-and-skip is opaque and untested (Design + Security):*
- Add `MalformedLine` type to `schema.rs` (file path, 1-indexed line number, parse-error string). Raw line content deliberately not captured to avoid leaking tampered payloads via the report.
- `read_all_events` now returns `(Vec<AuditEvent>, Vec<MalformedLine>)`. The four `get_by_*` methods discard the malformed list internally — their public signatures are unchanged.
- New public `corruption_report()` method returns just the malformed lines so the audit viewer UI / hook layer / tests can surface or count corruption deliberately. No rate-limiting or de-duplication — caller decides what to do.
- `eprintln!` removed entirely. Previously a placeholder; in Tauri sidecar contexts it would have been captured into OS logs / app diagnostics with no rate-limiting and no way for callers to observe.
- Test extended to assert the corruption report surfaces the right line number, file path, and a non-empty error message; new `test_corruption_report_is_empty_when_audit_history_is_clean`.

*Convergent — `read_all_events` reads as if it's the final shape (Design + Security):*
- Struct doc now states the Phase 1 size expectation (on the order of tens of MB of audit history) and points to the Phase 4 SqliteAuditStore migration in architecture Section 8.4 as the planned scaling answer.
- `// TODO(phase-4):` breadcrumb at the `read_all_events` doc comment so the next reader of that code site doesn't accept the full-scan as the intended implementation.

*Convergent (Nit) — redundant `event_after.id` reassignment in test:*
- Deleted; `test_event` already constructed the event with the correct id.

## Notes on what was deliberately NOT changed in this PR

Per the agreed scope (blocking + convergent only) and Kevin's explicit decisions on the protocol findings:

From #25 (suggestions and nits — still open):
- `read_dir` per-entry errors silently dropped
- Empty-line audit JSONL behaviour test
- Cross-file ordering test (multi-day audit history)
- Malformed-line behaviour test with broader fixture coverage
- `AuditEventType` parametric serialisation tests covering all 23 variants
- `AuditResult` naming collision

From the post-fix protocol run (single-reviewer suggestions/nits):
- Symlink / case-sensitivity defense-in-depth check in `read_all_events`
- Stronger test ordering across the malformed line
- `filter_events(predicate)` helper to consolidate the four `get_by_*` methods
- `AuditEventType` deriving `Eq` / `Hash`
- Empty-string `issue_ref` behaviour pinning
- Sequential-instance concurrency test for the `log()` doc claim
- Midnight-UTC filename derivation cosmetic ordering
- Test name referencing the private function rather than the public contract

These are real items but were not green-lit by Kevin in this pass; they remain visible in the protocol output and can be picked up as follow-up if they prove to matter in practice.

## Testing

```
$ cargo test --lib audit
running 14 tests
...
test result: ok. 14 passed; 0 failed
```

## References

- Closes #5
- Partially closes #25 (blocking + convergent items only; suggestions and nits remain open)
- Architecture doc: [Section 8 — Audit Trail](docs/architecture/sdlc-agent-architecture-research-v4.md)
- [ADR-001 — Audit Store JSONL File Granularity](docs/adr/001-audit-store-scoping.md)

## Open Questions

1. **Re-running the protocol on this PR is the right thing to do per ADR-005's targeted re-review pattern**, but ADR-005's *implementation* isn't built yet — only the decision is captured ([PR #28](https://github.com/kpcooney/saor/pull/28) pending). Want me to (a) skip re-review for this PR and rely on your manual review of the diff (smaller path), (b) do a manual proto-implementation of the targeted re-review to verify the convergent fixes, or (c) wait until ADR-005's implementation lands and run it cleanly then?
2. Confirm the deferred items (both #25's open items and the post-protocol single-reviewer items listed above) stay deferred. My read is yes — they're real but each is small enough to address if/when they prove to matter.

## Checklist

- [x] Tests added/updated and passing (`cargo test --lib audit`: 14 passed)
- [x] Lint clean (`cargo build --lib`)
- [x] Module-level documentation updated
- [x] Follows coding standards for Rust per CLAUDE.md
- [x] PR description references the issue being closed (#5) and the partial-close (#25)