### PR TITLE
docs: add session 001 handoff summary

### DIFF
--- a/docs/handoff/session-001.md
+++ b/docs/handoff/session-001.md
@@ -1,0 +1,103 @@
+# Session 001 — Handoff Summary
+
+**Date**: 2026-05-06
+**Issues worked**: #20, #22, #24, #25, #27, #30 (and partial-closes on #4, #5)
+
+## What was done
+
+This session built the foundational stores AND the review-assistance protocol that's now used to review every Phase 1 PR.
+
+### Phase 1 stores (the originally-scoped work)
+
+- **Memory store with FTS5** — [PR #26](https://github.com/kpcooney/saor/pull/26), closes #4 and partially #24. Cherry-picked from a prior bundled branch, dropped unrelated `lib.rs` reformatting, then added blocking + convergent fixes from the protocol's first run on it (BM25 non-tautology tests, FTS sync trigger tests for delete/update, `MemoryError::InvalidMetadata` variant + `unwrap_row_to_entry_error` helper). [ADR-003 — FTS5 Index Sync Strategy](docs/adr/003-fts5-index-sync-strategy.md) was added alongside.
+- **Audit store** — [PR #29](https://github.com/kpcooney/saor/pull/29), closes #5 and partially #25. Same pattern: cherry-pick + blocking/convergent fixes (`get_by_issue` implementation, log-and-skip with structured `MalformedLine` corruption report instead of `eprintln!`, `log()` doc comment tightened to be honest about POSIX append atomicity limits, `// TODO(phase-4):` breadcrumb at the read site).
+
+### Review-assistance protocol (meta-tooling, not in original Phase 1 scope)
+
+This was built mid-session because PR review was bottlenecking everything. It's now the active aid for every PR.
+
+- **[ADR-004 — Review Assistance Protocol](docs/adr/004-review-assistance-protocol.md)** ([PR #21](https://github.com/kpcooney/saor/pull/21), closes #20). Three blind reviewer agents (Design & Code Quality, Security & Edge Cases, Testability & Behavior) plus a coordinator. Agents are advisory; Kevin is always the merge gate. Built specifically with no automated merge gating to avoid LLM rubber-stamping.
+- **Protocol implementation** ([PR #23](https://github.com/kpcooney/saor/pull/23), closes #22). Reviewer + coordinator prompts under `standards/review-assistance/`, `/review-branch` slash command at `.claude/commands/review-branch.md`, CLAUDE.md "Review Assistance Protocol" section.
+- **[ADR-005 — Targeted Re-Review Pattern](docs/adr/005-targeted-re-review-pattern.md)** ([PR #28](https://github.com/kpcooney/saor/pull/28), closes #27). Designed because a blind full re-review on PR #26 was noisy/unreliable. Each re-reviewer evaluates only its own prior concerns against the diff of the fix and emits per-concern verdicts (Addressed / Partially / Not / No-longer-applicable) with evidence cited.
+- **Re-review implementation** ([PR #31](https://github.com/kpcooney/saor/pull/31), closes #30). Four re-reviewer prompt files, single `/review-branch --review-fixes` flag (Kevin chose this over a separate `/re-review-branch` command for consistency), `.claude/review-state/<branch>/<timestamp>/` persistence with keep-last-5 prune.
+
+## What's in progress
+
+**Nothing.** Every PR opened this session is merged. There are no open branches with uncommitted work. The `4/memory-audit-stores` branch in the user's main worktree (`/Users/kpcooney/saor`) is now superseded by the merged work and can be deleted at the user's discretion.
+
+## What's next
+
+Order recommended last in the session:
+
+1. **#10 — audit logging PostToolUse hook** (`scope:audit`). Smallest, closest to the just-merged audit store, validates the store under realistic load. Kevin signaled "ok continue as is" toward this.
+2. **#7 — agent identity schema and scope enforcement** (`scope:agents`). Foundational for #11.
+3. **#8 — memory MCP server** (`scope:mcp`). Wraps `SqliteMemoryStore` behind MCP tools.
+4. **#6 — reference resolver** + **#9 — reference resolver MCP tool** (`scope:mcp`). #9 wraps #6.
+5. **#11 — single Code Agent integration** (`scope:agents`). The big integration moment. Depends on #7, #8, #10. This is the visceral Phase 1 milestone — first agent run end-to-end.
+6. **#12 — Tauri IPC commands** (`scope:tauri`). Can start in parallel with the above.
+7. **#13 — basic UI** (`scope:frontend`). Depends on #12 for inspector views.
+
+#11 is roughly half the remaining effort. Phase 2 (coordinator agents + handoff protocol) starts after a single Code Agent runs end-to-end on a real task.
+
+Open follow-up issues from the protocol:
+
+- **#24** — memory store deferred items (suggestions + nits the protocol surfaced; not blocking for #4's close)
+- **#25** — audit store deferred items (same shape)
+
+These are not on the critical path; pick up if/when relevant.
+
+## Key context for the next session
+
+### The (a) flow for protocol findings — non-negotiable
+
+After running `/review-branch` (or `/review-branch --review-fixes`):
+
+1. Post the coordinator synthesis to Kevin
+2. **Wait** for his per-finding nod
+3. Fix only the items he green-lit
+4. Push as a new commit on the same branch
+
+**Do NOT collapse synthesis-and-act into one step.** This was an explicit course-correction during the session — Kevin wants to understand each bug + proposed fix before approving, both for learning value and to retain agency over what gets fixed. See `feedback_protocol_findings_workflow.md` in the saor memory directory.
+
+When Kevin doesn't recognise something the protocol flagged (e.g., he asked "what is `eprintln!`?"), explain it concisely so he can make an informed decision.
+
+### Other Kevin preferences saved as memory
+
+- **Focused PRs** — one issue per PR, even at cost of a rebase or cherry-pick. Don't bundle "while I'm here" cleanups. (`user_pr_scope_preference.md`)
+- **Consistent slash command surfaces** — single command + flag preferred over parallel commands for variants of the same protocol. (`user_consistent_command_surfaces.md`) Example: he asked the re-review be folded into `/review-branch --review-fixes` rather than a separate `/re-review-branch`.
+- **Phase numbers in TODOs must match the architecture doc.** Don't trust reviewer-suggested phase numbers blindly — verify against `docs/architecture/sdlc-agent-architecture-research-v4.md`. (`feedback_phase_numbers_match_architecture.md`)
+
+### Protocol gotchas worth remembering
+
+- **Reviewer prompts have explicit "no preamble" rules.** Each reviewer's response must begin with its role heading (e.g., `# Review — Design & Code Quality`). Anything before is a violation, but agents do still occasionally narrate. The strictness was added after the first dry-run produced ~20 lines of "thinking out loud" before the structured output.
+- **The slash command writes large artefacts to `/tmp/saor-review-*` files** rather than inlining into Task prompts. Inlining 1000+ lines hits input size limits. The same pattern applies for re-review (`/tmp/saor-rereview-*`).
+- **Run state persists at `.claude/review-state/<branch>/<timestamp>/`** with reports + synthesis + meta.json. Pruned to 5 most recent runs per branch automatically. Branch names with slashes (e.g., `4/sqlite-memory-store`) create nested directories — intended.
+- **Re-review is axis-isolated** — each re-reviewer sees ONLY its own prior report, not the others. The whole point is to evaluate concerns within the same axis that originated them.
+- **The dry-run for ADR-005's implementation (PR #31) was deferred to first real use.** First time you invoke `/review-branch --review-fixes` is the live test. If something breaks, the persistence layer (`mkdir`, file copy, meta.json) is the most likely place — it's the part with no test coverage.
+
+### Things that didn't work / we course-corrected on
+
+- **Bundled branch for #4 + #5.** Original work was on `4/memory-audit-stores` with both stores. Per Kevin's "focused PRs" preference, split into separate PRs (#26 for memory, #29 for audit). Costs a rebase but produces cleaner review surface.
+- **Acting unilaterally on protocol findings.** Did this on PR #26, Kevin pushed back, established the (a) flow above. ADR-005 is partly the response — without a defined re-review step, the protocol's loop wasn't actually closed.
+- **`eprintln!` for malformed JSONL warnings.** First fix attempt; the protocol caught it as an opaque side-channel. Replaced with structured `MalformedLine` corruption report returned to callers.
+- **`MemoryError::InvalidMetadata` initially unreachable** through `read_entry`'s `map_err` (got buried in `MemoryError::Database(FromSqlConversionFailure(...))`). Protocol caught this; fix added `unwrap_row_to_entry_error` helper.
+- **Delete-trigger tests asserted via `keyword_search`'s JOIN, which masked broken-trigger behaviour.** Protocol caught; fix added `count_fts_matches` helper that queries `memory_fts` directly.
+
+### Project state at session end
+
+- Main is at `8e47252` (PR #31 merge).
+- Phase 1: ~30% done by issue count. ADR-001, ADR-002, ADR-003, ADR-004, ADR-005 all merged (status field still says `proposed` in the files — there's a known docs-housekeeping gap, see [docs/adr/README.md](../adr/README.md) which says merged ADRs should be `accepted`; nobody has updated them yet).
+- Open follow-up items: #24 (memory deferrals), #25 (audit deferrals). Both are tracked, neither is blocking.
+- The user's main worktree at `/Users/kpcooney/saor` may still be on the obsolete `4/memory-audit-stores` branch — worth the user pruning at their discretion.
+
+### Memory directory state
+
+Five memories saved at `/Users/kpcooney/.claude/projects/-Users-kpcooney-saor/memory/`:
+
+- `feedback_protocol_findings_workflow.md` — the (a) flow
+- `user_pr_scope_preference.md`
+- `user_consistent_command_surfaces.md`
+- `feedback_phase_numbers_match_architecture.md`
+- `project_review_assistance_protocol.md` — full protocol state, both ADRs implemented
+
+The next session should read these before starting work — they capture conventions that aren't in CLAUDE.md.


### PR DESCRIPTION
## Summary

Session 001 handoff per CLAUDE.md's session management protocol. Tiny PR — one new file at [docs/handoff/session-001.md](docs/handoff/session-001.md).

## What it captures

- **What was done**: foundational stores (memory + audit) plus the bonus review-assistance protocol (ADR-004 + ADR-005 both implemented). PR list with traceability.
- **What's in progress**: nothing — every session-opened PR is merged.
- **What's next**: #10 (audit hook) → #7 (identity) → #11 (Code Agent integration) is the recommended order. #11 is the visceral Phase 1 milestone (first agent run end-to-end).
- **Key context for the next session**: the (a) flow for protocol findings (non-negotiable), Kevin preferences saved as memory, protocol gotchas (no-preamble rule, /tmp file pattern, axis isolation, deferred dry-run), things that didn't work and how we course-corrected.

The next session should read this file plus the five memories at `/Users/kpcooney/.claude/projects/-Users-kpcooney-saor/memory/` before starting work.

## Testing

N/A — documentation only.

## References

- CLAUDE.md: Session Management → Handoff Summaries section