### PR TITLE
docs: drop handoff-summary convention from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,32 +256,15 @@ After completing each issue (or when context is running low), post a brief statu
 - Context: (estimated context usage — low/medium/high — and whether to continue or hand off)
 ```
 
-### Handoff Summaries
+### Resuming after a session ends
 
-When a session ends (context exhaustion, natural stopping point, or explicit request), write a handoff summary to `docs/handoff/session-NNN.md` (zero-padded three digits). This file gives the next session everything it needs to pick up the work without re-reading the entire codebase.
+No per-session handoff file is written. The next session orients via:
 
-Handoff format:
+- **The auto-memory system** at `~/.claude/projects/<project>/memory/` — captures conventions, preferences, and protocol state that aren't in the codebase.
+- **`git log`, open PRs, open issues** — capture work history, in-progress state, and what's next.
+- **CLAUDE.md and the architecture doc** — capture project rules and design.
 
-```markdown
-# Session NNN — Handoff Summary
-
-**Date**: YYYY-MM-DD
-**Issues worked**: #NN, #NN
-
-## What was done
-(Concise list of completed work, with PR/commit references)
-
-## What's in progress
-(Anything started but not finished — branch names, open PRs, known issues)
-
-## What's next
-(Prioritized list of next tasks, with issue numbers)
-
-## Key context for the next session
-(Anything the next session needs to know that isn't in CLAUDE.md or the architecture doc — gotchas, decisions made during the session, things that didn't work)
-```
-
-The next session should read the most recent handoff file and CLAUDE.md before starting work.
+Handoff files were tried earlier and dropped because every section duplicated one of the above sources and became stale immediately.
 
 ## What Not To Do
 


### PR DESCRIPTION
## Summary

Removes the "Handoff Summaries" subsection from CLAUDE.md's Session Management section. Replaces it with a short "Resuming after a session ends" note pointing readers at memory + git history + issue tracker + architecture doc as the orientation surfaces.

## Changes

- `CLAUDE.md`: -23 / +6 lines. Removed the per-session handoff-file convention; kept Status Reports (still useful mid-session).

## Why

Every section of a handoff file has a better home today:

| Handoff section | Better home today |
|---|---|
| What was done | `git log`, merged PRs |
| What's in progress | Open branches, open PRs |
| What's next | Open issues + priority |
| Key context for next session | Memory entries (more durable, auto-loaded) |
| Things that didn't work | Commit messages, PR comments |

The handoff convention pre-dated heavy use of the auto-memory system. Now it's substantially redundant. Handoff files also become stale almost immediately — useful as a one-time read on resume, then dead weight. The "session-NNN" numbering is itself a smell (what defines a session? compaction? `/clear`? a new worktree?).

## Testing

N/A — documentation only.

## References

- Closes #33
- Closed without merging: [PR #32](https://github.com/kpcooney/saor/pull/32) — the handoff file that prompted the conversation. No `docs/handoff/` directory exists on main.

## Open Questions

None — the decision was made in conversation and this PR is the cleanup.

## Checklist

- [x] CLAUDE.md edit applied
- [x] Status Reports subsection retained
- [x] PR description follows pr-format standard