### PR TITLE
docs(review-assistance): quote offending code in review output (#39)

### DIFF
--- a/standards/review-assistance/coordinator.md
+++ b/standards/review-assistance/coordinator.md
@@ -41,6 +41,7 @@ Your job is **convergence and divergence**: what did multiple reviewers flag (si
 - **Severity**: Blocking | Suggestion | Nit
 - **Raised by**: Design & Code Quality, Security & Edge Cases [list reviewers who flagged it]
 - **Locations**: file:line, file:line [merged across reviewers]
+- **Code**: the fenced snippet from the originating report(s), carried through verbatim (omit if no reviewer quoted code for this concern)
 - **Summary**: Synthesised description, drawing on what each reviewer said.
 - **Why it matters**: Combined rationale.
 
@@ -51,6 +52,7 @@ Your job is **convergence and divergence**: what did multiple reviewers flag (si
 ### <Concern title>
 - **Raised by**: <reviewer>
 - **Location**: …
+- **Code**: the fenced snippet from the originating report, carried through verbatim (omit if none)
 - **Summary**: …
 - **Why it matters**: …
 
@@ -103,5 +105,6 @@ The three full reports follow, for spot-checking the synthesis above:
 - **Do not invent severity.** If a reviewer marked a concern Suggestion, you do not promote it to Blocking just because another reviewer raised something nearby. The cluster severity is the maximum of the *reported* severities, not your judgment of how serious it really is.
 - **Do not invent concerns.** Synthesis is a re-organisation of what the reviewers said. If you notice something the reviewers missed, that is not your job to surface — your job is to faithfully synthesise. (This protects against the coordinator becoming a fourth, hidden reviewer.)
 - **Cluster conservatively.** When in doubt about whether two concerns are the same, list them separately. Spurious clustering hides real signal.
+- **Preserve quoted code, don't author it.** When a reviewer's concern includes a **Code** block, carry it through verbatim into the convergent or single-reviewer-blocking entry so Kevin sees the offending lines inline. If clustered reviewers quoted overlapping but different snippets, keep the most complete one. Never fabricate code a reviewer did not quote — if no reviewer quoted code, omit the Code field.
 - **Always include the raw reports.** Kevin must be able to verify your synthesis by reading the originals.
 - **If a reviewer report is missing, malformed, or empty**, say so explicitly in a `## Reviewer report issues` section before the synthesis, and proceed with whatever reports are usable. Do not silently substitute.

--- a/standards/review-assistance/design-and-code-quality.md
+++ b/standards/review-assistance/design-and-code-quality.md
@@ -77,6 +77,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 ### <Concern title>
 - **Location**: path/to/file.rs:42 (or "general" if architectural)
+- **Code**: a fenced code block quoting the exact line(s) the concern is about, copied from the file (not paraphrased), captioned with `file:line`. Omit for "general"/architectural concerns with no single location.
 - **Concern**: What is wrong, in one or two sentences.
 - **Why it matters**: Concrete reason this should not merge as-is.
 
@@ -87,6 +88,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 ### <Concern title>
 - **Location**: …
+- **Code**: fenced snippet of the exact line(s), captioned `file:line` (omit if no single location)
 - **Concern**: …
 - **Why it matters**: …
 
@@ -101,6 +103,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 - **Your response must begin with the heading `# Review — Design & Code Quality`.** Anything before that heading — preamble, "thinking out loud", "Let me check…", numbered observations, "Now I have enough context" — is a violation of this prompt and pollutes the coordinator's input. Do your reasoning silently while reading the inputs; emit only the structured output.
 - **Enumerate, don't narrate.** Do not summarise the diff. Do not write "this code does X". Surface concerns only.
 - **Be specific.** "This function is confusing" is not actionable. "`resolveScope` at scope.rs:42 mixes validation and persistence — split at the validation boundary" is.
+- **Quote the offending code.** Every Blocking and Suggestion concern with a concrete location must include a **Code** block: a fenced snippet of the exact line(s) read from the file, captioned `file:line`. Copy the real code — do not paraphrase. Keep it tight (roughly ≤ 6 lines, just enough to see the issue). Nits stay one-line and omit the Code block.
 - **Severity honesty.** Do not inflate nits to suggestions, do not downgrade real problems to nits. Match the severity to your actual confidence and concern.
 - **When uncertain, escalate.** If you cannot confidently judge a concern, surface it under Suggestions or Blocking with "Uncertain — recommend Kevin review" in the Why-it-matters line, and add it to the Summary's uncertainty flag.
 - **No verdict.** Do not say "approve" or "block". Do not recommend merging or not merging. List concerns and let the synthesis stage and the human handle it.

--- a/standards/review-assistance/re-review-coordinator.md
+++ b/standards/review-assistance/re-review-coordinator.md
@@ -44,6 +44,7 @@ You **do not issue a verdict on the PR**. You do not say "ready to merge" or "ne
 - **Reviewer**: Design & Code Quality | Security & Edge Cases | Testability & Behavior
 - **Original severity**: Blocking | Suggestion | Nit
 - **Verdict**: Partially addressed | Not addressed
+- **Code (from fix)**: the reviewer's **Code (from fix)** snippet, carried through verbatim (omit if the reviewer quoted none)
 - **Why it remains open**: One or two sentences from the reviewer's reasoning, paraphrased faithfully.
 
 ## Resolution status
@@ -67,6 +68,7 @@ You **do not issue a verdict on the PR**. You do not say "ready to merge" or "ne
 - **Severity**: Blocking | Suggestion | Nit (the maximum reported severity across reviewers)
 - **Raised by**: <reviewer list>
 - **Locations**: <merged file:line>
+- **Code**: the fenced snippet from the originating re-reviewer report(s), carried through verbatim (omit if none)
 - **Summary**: Synthesised description.
 
 ## New single-reviewer concerns from the fix
@@ -105,5 +107,6 @@ The three full reports follow, for spot-checking the synthesis above:
 - **Do not invent verdicts.** If a reviewer marked a concern `Partially addressed`, you do not promote it to `Addressed` because you think the fix looks good. The reviewer's verdict is what you synthesise.
 - **Do not invent concerns.** Synthesis re-organises what the reviewers said. If you notice something the reviewers missed, that is not your job to surface — your job is faithful synthesis. (This protects against the coordinator becoming a fourth, hidden reviewer.)
 - **Faithful paraphrasing is allowed.** The "Why it remains open" line in `Outstanding work` may compress a reviewer's reasoning into one sentence, but it must not change the meaning.
+- **Preserve quoted code, don't author it.** When a re-reviewer included a **Code (from fix)** or **Code** block, carry it through verbatim so Kevin sees the relevant lines inline. Never fabricate code a reviewer did not quote — if none was quoted, omit the field.
 - **Always include the raw reports.** Kevin must be able to verify your synthesis by reading the originals.
 - **If a reviewer report is missing or malformed**, say so explicitly in a `## Re-reviewer report issues` section before the synthesis, and proceed with whatever reports are usable. Do not silently substitute.

--- a/standards/review-assistance/re-review-design-and-code-quality.md
+++ b/standards/review-assistance/re-review-design-and-code-quality.md
@@ -46,6 +46,7 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 ### <Original concern title>
 - **Verdict**: Addressed | Partially addressed | Not addressed | No longer applicable
 - **Evidence**: path/to/file.rs:42 in the fix diff (or "no evidence in fix diff")
+- **Code (from fix)**: a fenced snippet of the changed line(s) your evidence turns on, copied from the fix diff, captioned `file:line` (include for Addressed / Partially addressed; omit when there's nothing in the fix to show)
 - **Reasoning**: One or two sentences explaining the verdict.
 
 ### <Next prior concern>
@@ -55,6 +56,7 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 
 ### <Concern title> (Blocking | Suggestion | Nit)
 - **Location**: path/to/file.rs:42 (in the fix diff)
+- **Code**: fenced snippet of the exact line(s) from the fix diff, captioned `file:line`
 - **Concern**: What is wrong with the change.
 - **Why it matters**: Concrete reason this should not merge as-is.
 ```
@@ -66,5 +68,6 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 - **Evidence is required for `Addressed`.** A verdict of `Addressed` without a file:line citation in the fix diff is not allowed. If you cannot cite the change, the fix did not resolve the concern from your axis's perspective.
 - **`Partially addressed` and `Not addressed` are first-class.** Use them when honest. They are the most useful signal Kevin can receive — they tell him the loop is not yet closed.
 - **Be specific.** "Partially addressed" without explaining what remains is not actionable. "The fix renamed the variable but did not change the unsafe unwrap at line 42 — that's the original concern's blocking aspect" is.
+- **Show the code.** For each Addressed / Partially addressed verdict, include a **Code (from fix)** block quoting the actual changed line(s) your evidence cites — copied from the fix diff, not paraphrased. New concerns include a **Code** block the same way the initial review does. Keep snippets tight (roughly ≤ 6 lines).
 - **Do not re-discover.** Concerns that were not in your prior report belong only in the `New concerns from the fix` section, and only if they are caused by changes in the fix diff. Do not reach into unchanged code.
 - **No verdict on the PR overall.** You do not say "approve" or "block" or "ship it" or "needs more work." You list verdicts per concern; Kevin decides what to do with them.

--- a/standards/review-assistance/re-review-security-and-edge-cases.md
+++ b/standards/review-assistance/re-review-security-and-edge-cases.md
@@ -40,12 +40,14 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 ### <Original concern title>
 - **Verdict**: Addressed | Partially addressed | Not addressed | No longer applicable
 - **Evidence**: path/to/file.rs:42 in the fix diff (or "no evidence in fix diff")
+- **Code (from fix)**: a fenced snippet of the changed line(s) your evidence turns on, copied from the fix diff, captioned `file:line` (include for Addressed / Partially addressed; omit when there's nothing in the fix to show)
 - **Reasoning**: One or two sentences. Be concrete about whether the failure scenario you described is still reachable.
 
 ## New concerns from the fix
 
 ### <Concern title> (Blocking | Suggestion | Nit)
 - **Location**: path/to/file.rs:42 (in the fix diff)
+- **Code**: fenced snippet of the exact line(s) from the fix diff, captioned `file:line`
 - **Concern**: What is exploitable or broken in the new code.
 - **Why it matters**: The concrete consequence — data corruption, secret exposure, crash.
 ```
@@ -57,4 +59,5 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 - **Evidence is required for `Addressed`.** Cite the change. If you cannot cite it, the fix did not resolve the concern from a security perspective.
 - **`Partially addressed` and `Not addressed` are first-class.** Soft fixes are common in security review — name them honestly.
 - **Do not re-discover concerns from unchanged code.** Only flag new concerns caused by the fix diff itself in the `New concerns from the fix` section.
+- **Show the code.** For each Addressed / Partially addressed verdict, include a **Code (from fix)** block quoting the actual changed line(s) your evidence cites — copied from the fix diff, not paraphrased. New concerns include a **Code** block the same way the initial review does. Keep snippets tight (roughly ≤ 6 lines).
 - **No verdict on the PR overall.**

--- a/standards/review-assistance/re-review-testability-and-behavior.md
+++ b/standards/review-assistance/re-review-testability-and-behavior.md
@@ -42,12 +42,14 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 ### <Original concern title>
 - **Verdict**: Addressed | Partially addressed | Not addressed | No longer applicable
 - **Evidence**: path/to/test_file.rs:42 in the fix diff (or "no evidence in fix diff")
+- **Code (from fix)**: a fenced snippet of the new/changed test (or source) line(s) your evidence turns on, copied from the fix diff, captioned `file:line` (include for Addressed / Partially addressed; omit when there's nothing in the fix to show)
 - **Reasoning**: One or two sentences. Name the bug class the new test catches (or fails to catch).
 
 ## New concerns from the fix
 
 ### <Concern title> (Blocking | Suggestion | Nit)
 - **Location**: path/to/file.rs:42 (in the fix diff)
+- **Code**: fenced snippet of the exact line(s) from the fix diff, captioned `file:line`
 - **Concern**: What is missing or weak about the new code's testability.
 - **Why it matters**: What bug class would slip through given the current test suite.
 ```
@@ -59,4 +61,5 @@ N concerns: A addressed, P partially, X not addressed, M no longer applicable. K
 - **Evidence is required for `Addressed`.** Cite the test (file:line). If you cannot cite the test, the fix did not resolve the testability concern.
 - **`Partially addressed` is the right verdict for "test exists but is weak".** Use it when the test is present but doesn't bind the bug class the prior concern named.
 - **Do not re-discover concerns from unchanged code.** New concerns must be caused by the fix diff.
+- **Show the code.** For each Addressed / Partially addressed verdict, include a **Code (from fix)** block quoting the actual changed line(s) your evidence cites — copied from the fix diff, not paraphrased. New concerns include a **Code** block the same way the initial review does. Keep snippets tight (roughly ≤ 6 lines).
 - **No verdict on the PR overall.**

--- a/standards/review-assistance/security-and-edge-cases.md
+++ b/standards/review-assistance/security-and-edge-cases.md
@@ -90,6 +90,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 ### <Concern title>
 - **Location**: path/to/file.rs:42 (or "general")
+- **Code**: a fenced code block quoting the exact line(s) the concern is about, copied from the file (not paraphrased), captioned with `file:line`. Omit for "general" concerns with no single location.
 - **Concern**: What is exploitable or broken, with the failure scenario.
 - **Why it matters**: The concrete consequence — data corruption, secret exposure, crash, etc.
 
@@ -97,6 +98,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 ### <Concern title>
 - **Location**: …
+- **Code**: fenced snippet of the exact line(s), captioned `file:line` (omit if no single location)
 - **Concern**: …
 - **Why it matters**: …
 
@@ -109,6 +111,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 - **Your response must begin with the heading `# Review — Security & Edge Cases`.** Anything before that heading — preamble, "thinking out loud", "Let me check…", numbered observations, "Now I have enough context" — is a violation of this prompt and pollutes the coordinator's input. Do your reasoning silently while reading the inputs; emit only the structured output.
 - **Concrete failure scenarios.** "This is unsafe" is not actionable. "If `request.path` contains `../`, this opens files outside the project directory" is.
+- **Quote the offending code.** Every Blocking and Suggestion concern with a concrete location must include a **Code** block: a fenced snippet of the exact line(s) read from the file, captioned `file:line`. Copy the real code — do not paraphrase. Keep it tight (roughly ≤ 6 lines, just enough to see the issue). Nits stay one-line and omit the Code block.
 - **Severity honesty.** A theoretical concern with no realistic exploit path is a Suggestion or Nit, not Blocking. A real exploit path with a concrete consequence is Blocking. Do not inflate.
 - **When uncertain, escalate.** If you suspect an issue but cannot confirm the exploit path, list it under Suggestions with "Uncertain — recommend Kevin review" and add an uncertainty flag to the Summary.
 - **No verdict.** Do not approve or block. Surface concerns and let the synthesis and the human handle it.

--- a/standards/review-assistance/testability-and-behavior.md
+++ b/standards/review-assistance/testability-and-behavior.md
@@ -76,6 +76,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 ### <Concern title>
 - **Location**: path/to/test_file.rs:42 (or the source file lacking a test)
+- **Code**: a fenced code block quoting the exact line(s) the concern is about — the untested source path, or the test that's shape-only — copied from the file (not paraphrased), captioned with `file:line`. Omit when the concern is the *absence* of a test with no specific line to point at.
 - **Concern**: What is missing or wrong, in one or two sentences.
 - **Why it matters**: What bug class would slip through given the current test suite.
 
@@ -83,6 +84,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 ### <Concern title>
 - **Location**: …
+- **Code**: fenced snippet of the exact line(s), captioned `file:line` (omit when the concern is a missing test with no specific line)
 - **Concern**: …
 - **Why it matters**: …
 
@@ -95,6 +97,7 @@ Produce a markdown document with this exact structure. Omit empty sections.
 
 - **Your response must begin with the heading `# Review — Testability & Behavior`.** Anything before that heading — preamble, "thinking out loud", "Let me check…", numbered observations, "Now I have enough context" — is a violation of this prompt and pollutes the coordinator's input. Do your reasoning silently while reading the inputs; emit only the structured output.
 - **Be specific about what's missing.** "Tests are weak" is not actionable. "No test exercises `keyword_search` with a query that matches multiple entries — BM25 ranking is untested" is.
+- **Quote the offending code.** Every Blocking and Suggestion concern with a concrete location must include a **Code** block: a fenced snippet of the exact line(s) read from the file (the untested source, or the shape-only test), captioned `file:line`. Copy the real code — do not paraphrase. Keep it tight (roughly ≤ 6 lines). When the concern is a missing test with no line to point at, omit the Code block and say so in the Concern. Nits stay one-line and omit the Code block.
 - **Severity honesty.** Missing coverage of a documented contract is Blocking. Missing coverage of an unlikely edge case is a Suggestion. Test naming style is a Nit.
 - **Distinguish "missing test" from "untestable code".** If the code is structured so that testing requires elaborate mocking that CLAUDE.md says to avoid, the concern is testability, not coverage.
 - **When uncertain, escalate.** If unsure whether a behaviour is contract or implementation detail, flag it under Suggestions and note the uncertainty.


### PR DESCRIPTION
## Summary

Adds an inline **Code** snippet to every Blocking/Suggestion concern across the review-assistance protocol, so the rendered markdown carries **file + line + the actual code + concern + scenario** — skimmable in one pass instead of requiring a jump to each `file:line`. This mirrors what makes the built-in `/code-review` output fast to read, but keeps our markdown format (no JSON).

## Changes

Pure prompt/behaviour change under `standards/review-assistance/` — no code touched. Applied to **both modes** of `/review-branch` (one feature, done completely):

**Initial review** (commit 1)
- The three reviewer prompts (`design-and-code-quality`, `security-and-edge-cases`, `testability-and-behavior`) gain a `**Code**` field in the Blocking/Suggestion templates, plus a behavioural rule: quote the **real** lines read from the file (no paraphrase, ~6 lines max), captioned `file:line`. Nits stay one-liners with no Code block.
- `coordinator.md` gains a `**Code**` field in the convergent and single-reviewer-blocking templates and a rule to **carry the snippet through verbatim** (never fabricate code a reviewer didn't quote).

**Re-review** (commit 2)
- The three re-reviewer prompts gain `**Code (from fix)**` on each prior-concern verdict (the changed lines the verdict turns on) and a `**Code**` field on new-concern entries.
- `re-review-coordinator.md` preserves both verbatim.

### Sample of the resulting format

> ### Expiry check fails open on invalid dates
> - **Location**: `agents/src/hooks/scope-enforcement.ts:382`
> - **Code**:
>   \`\`\`ts
>   return now.getTime() >= new Date(expiresAt).getTime();
>   \`\`\`
> - **Concern**: `new Date("garbage").getTime()` is `NaN`; `n >= NaN` is `false`, so a malformed expiry reads as never-expired.
> - **Why it matters**: Fails open on a core security boundary.

### Non-obvious decision

The templates describe the Code field rather than embedding a live nested code-fence, because the Output Format blocks are themselves inside a fenced ```markdown block — a real nested fence would terminate it early. The behavioural rule + the sample above make the expected rendered output unambiguous.

## Testing

No automated tests — these are agent prompts. Verified by inspection: all 8 files carry the new field, the existing structure/headings are intact, and the README (which doesn't describe the per-concern format) needs no change. The change is exercised the next time `/review-branch` runs; the migration path noted in CLAUDE.md (harness reads these prompts via `standards://review-assistance/<role>`) is unaffected — only the Output Format section changed.

## References

- Closes #39
- Related ADRs: ADR-004 (review-assistance protocol), ADR-005 (targeted re-review pattern)

## Open Questions

None. If the `**Code (from fix)**` vs `**Code**` distinction in the re-review path feels like overkill, happy to collapse them to a single `**Code**` label.

## Checklist

- [x] Tests added/updated and passing — N/A (prompt-only change)
- [x] Lint clean — N/A (markdown)
- [x] Module-level documentation updated (the prompt files are the docs)
- [x] Follows the existing prompt conventions
- [x] PR description references the issue being closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)