### PR TITLE
docs(architecture): record review-truth model (ADR-007 + CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Examples: `12/sqlite-memory-store`, `15/jsonl-audit-writer`, `18/code-agent-iden
 2. **Create a feature branch** from `main` using the naming convention above.
 3. **Implement on the branch.** Commit early and often using Conventional Commits. Each commit should be a coherent unit — not a single massive commit at the end.
 4. **Write tests** alongside the implementation (see Testing section below).
-5. **Open a pull request on GitHub** when the work is ready for review. The PR description must follow the PR format standard (`standards/documentation-standards/pr-format.md`): summary, changes made, testing performed, traceability references (Issue, Epic if applicable, related ADRs), and any open questions.
+5. **Open a pull request on GitHub** when the work is ready for review. The PR description must follow the PR format standard (`standards/documentation-standards/pr-format.md`): summary, changes made, testing performed, traceability references (Issue, Epic if applicable, related ADRs), and any open questions. The PR must be green on the full suite and the mutation score (see Testing — Acceptance tier) before requesting review.
 6. **Review loop.** Kevin will review the PR on GitHub. This is a conversation, not a rubber stamp. The loop works like this:
 
    a. **Kevin leaves review comments** — questions, critiques, change requests, or approvals on specific lines or the PR as a whole.
@@ -189,6 +189,16 @@ Documentation should help someone not familiar with the codebase understand what
 ### Testing
 
 Tests are required for all non-trivial functionality. They go through PR review alongside the implementation — not as a separate afterthought.
+
+#### Acceptance tier and where review-truth comes from
+
+Kevin cannot line-by-line review across Rust, Svelte, and TypeScript. The authoritative signal that an issue is done is therefore neither Kevin reading the diff nor the agent's own summary of its work — it is machine-checked behavior plus mutation score. See [ADR-007](docs/adr/007-review-truth-model.md).
+
+- **Acceptance tier**: a tagged test tier, separate from unit tests. Each acceptance test maps to a GitHub issue and is the executable definition of done for it. Acceptance tests use real stores (temp-dir files, in-memory SQLite) and verify side effects by reading them back — no mocks at this tier. Each includes a **negative control**, so a green result can't be green for the wrong reason.
+- **Mutation testing** runs on the load-bearing modules (identity/scope, audit, reference resolver, memory store, standards resolution). Mutation score — not coverage — measures whether the tests would actually catch a regression.
+- **PRs are gated** on the full suite and the mutation score being green before they reach Kevin.
+- **The PR summary and any agent self-review are orientation only.** They tell Kevin where to look; they do not close the issue. The green acceptance run, and where applicable the behavior Kevin observes, are what close it.
+- **Capabilities that touch the live Claude Agent SDK** (hook registration actually firing, a tool actually halted) get a small one-time human-observable integration check in addition to their machine-verifiable acceptance test.
 
 **Testing philosophy for Phase 1:**
 

--- a/docs/adr/007-review-truth-model.md
+++ b/docs/adr/007-review-truth-model.md
@@ -1,0 +1,109 @@
+# 007 — Machine-checked behavioral acceptance as the review authority
+
+**Status**: accepted
+
+## Context
+
+Kevin cannot fluently line-by-line review code across the three Phase 1
+languages (Rust, Svelte, TypeScript), and the project's direction is to delegate
+implementation to agents rather than have Kevin act as the manual line-level
+gate. A review model is therefore needed where the authoritative signal that an
+issue is "done" is neither (a) Kevin reading the diff — not feasible across these
+languages — nor (b) the agent's own change summary and self-review, which report
+intent and carry the author's own blind spots. The goal is an agent-independent
+source of truth for whether a capability actually works.
+
+The forces driving the decision:
+
+- Human diff review is not a reliable gate when the reviewer can't fluently read
+  the language.
+- An agent's change summary / self-review is advocacy, not verification — the
+  same lossy-summary problem the architecture already rejects for inter-agent
+  handoffs (reference over summary), reappearing at the human-review boundary.
+- The review signal must be a fact that a machine checked, not a claim someone
+  made.
+
+## Decision
+
+Make **machine-checked behavioral acceptance plus mutation testing** the
+authoritative review signal, and demote the agent's summary and self-review to
+orientation only.
+
+**Options considered:**
+
+- **Option A — Human line-by-line diff review** (the implicit status quo). Not
+  feasible across Rust/Svelte/TypeScript for this reviewer.
+- **Option B — Agent summarizes changes and synthesizes its own review; human
+  reads the report.** The report is intent, not behavior, and the human can't
+  backstop it the way they could backstop a human reviewer's miss.
+- **Option C — Machine-checked behavioral acceptance + mutation testing as the
+  authority; agent summary/self-review demoted to orientation.**
+- **Option D — Multi-agent test generation** (several test-tailored agents
+  authoring the test set). More test *authors* widen coverage but do not raise
+  the floor on test *quality*; without a deterministic judge it risks agents
+  grading agents. Deferred to Phase 2+.
+
+**Chosen approach**: Option C — it makes the source of truth an agent-independent
+fact a machine checked (behavior + mutation score), which is the only option
+that gives a reliable gate without requiring fluent human diff review.
+
+The chosen model has these specifics:
+
+- A tagged **acceptance tier**, separate from unit tests. Each acceptance test
+  maps to a GitHub issue and is the executable definition of done for it.
+- Acceptance tests use **real stores** (temp-dir files, in-memory SQLite) and
+  verify side effects by reading them back — no mocks at this tier.
+- Each acceptance test includes a **negative control**, so a green result can't
+  be green for the wrong reason (e.g., a hook that blocks everything must fail
+  the in-scope-allowed case).
+- **Mutation testing** runs on the load-bearing modules (identity/scope, audit,
+  reference resolver, memory store, standards resolution). Mutation score — not
+  coverage — is the measure of whether the tests would actually catch a
+  regression. It is the judge of test quality.
+- **PRs are gated** on the full suite and the mutation score being green before
+  they reach Kevin.
+- The **PR summary and any agent self-review are orientation only** — they
+  indicate where to look; they do not close the issue. The green acceptance run,
+  and where applicable the behavior Kevin observes, are what close it.
+- Capabilities that touch the **live Claude Agent SDK** (a hook actually firing,
+  a tool actually halted) get a small one-time **human-observable integration
+  check** in addition to their machine-verifiable acceptance test.
+
+Option D is explicitly out of scope for Phase 1. Revisit it only where the
+reasoning approach fundamentally differs (e.g., an adversarial/red-team
+perspective distinct from contract-conformance), and only on top of a
+deterministic judge — never instead of one.
+
+## Consequences
+
+**Positive:**
+- Review becomes runnable, not readable; the source of truth is
+  agent-independent and the definition of done is executable.
+- Authoring acceptance tests surfaces unspecified contracts early, while they're
+  cheap to pin.
+- Consistent with the project's existing "reference over summary" and "abstract
+  the backends" principles.
+
+**Negative / trade-offs:**
+- Mutation testing adds CI time and setup; the acceptance tier is upfront work.
+- A green suite proves the harness does what was *specified*, not that the
+  *right thing* was specified. Mutation testing mitigates this but does not
+  eliminate it, so load-bearing modules still warrant Kevin's eyes at the
+  contract/boundary level.
+
+**Neutral / notable:**
+- Multi-agent test generation (Option D) is deferred to Phase 2+, gated on a
+  deterministic judge existing first.
+- The per-issue work — adding a runnable acceptance check with a negative
+  control to each of the 13 Phase 1 issues as its definition of done — is a
+  separate follow-up; this ADR sets it as the standing policy.
+
+## References
+
+- Initiative: *(n/a)*
+- Epic: *(n/a)*
+- Issue: #43
+- Related ADRs: [001 — Audit Store File Granularity](001-audit-store-scoping.md)
+- Architecture doc: [Section 7.4 — Scope Enforcement via PreToolUse Hooks](../architecture/sdlc-agent-architecture-research-v4.md#74-scope-enforcement-via-pretooluse-hooks),
+  [Section 8 — Audit Trail](../architecture/sdlc-agent-architecture-research-v4.md#8-audit-trail)
+- CLAUDE.md: Testing section (Acceptance tier and where review-truth comes from)


### PR DESCRIPTION
## Summary

Records the **review-truth model** as an ADR and wires it into `CLAUDE.md`: the authoritative signal that an issue is done is machine-checked behavioral acceptance plus mutation score — not Kevin reading the diff (not feasible across Rust/Svelte/TypeScript) and not the agent's own summary/self-review (intent, not verification). Pre-approved with Kevin; opening for the normal review/merge loop.

## Changes

- **`docs/adr/007-review-truth-model.md`** (new, status `accepted`) — captures the context, the four options considered (human diff review; agent self-review; machine-checked acceptance + mutation testing; multi-agent test generation), and the chosen model: a tagged acceptance tier (real stores, negative controls, no mocks), mutation testing as the judge of test quality on load-bearing modules, PRs gated on suite + mutation score, agent summaries demoted to orientation, and a one-time human-observable integration check for live-SDK capabilities. Multi-agent test generation is explicitly deferred to Phase 2+ and only atop a deterministic judge.
- **`CLAUDE.md`** — two edits that make the ADR standing policy:
  - New "Acceptance tier and where review-truth comes from" subsection at the top of **Testing**, referencing ADR-007.
  - A sentence in the PR workflow step requiring the PR to be green on the full suite and the mutation score before review.

CLAUDE.md references the ADR, so they ship together (one PR), as instructed.

## Testing

Docs-only change — no code. Verified: the ADR conforms to the repo MADR template (`standards/documentation-standards/adr-format.md`), 007 is the next sequential number, and the architecture-doc anchors (Sections 7.4, 8) resolve to real headings.

## References

- Closes #43
- Related ADRs: [ADR-001 — Audit Store File Granularity](docs/adr/001-audit-store-scoping.md)
- Architecture doc: [Section 7.4](docs/architecture/sdlc-agent-architecture-research-v4.md#74-scope-enforcement-via-pretooluse-hooks), [Section 8 — Audit Trail](docs/architecture/sdlc-agent-architecture-research-v4.md#8-audit-trail)

## Open Questions

- The ADR is written with status `accepted` per the task instruction (the decision was already discussed and approved), rather than the usual `proposed`-until-merged. Flag if you'd prefer it land as `proposed` and flip on merge.
- No `architecture` label exists in the repo, so the issue is labeled `docs`. Say if you'd like an `architecture` label created.

## Checklist

- [x] Tests added/updated and passing — N/A (docs-only)
- [x] Lint clean — N/A (docs-only)
- [x] Module-level documentation updated — ADR added, CLAUDE.md updated
- [x] Follows coding standards for the language(s) modified
- [x] PR description references the issue being closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
