### PR TITLE
docs(standards): number concerns in review coordinator output

### DIFF
--- a/standards/review-assistance/coordinator.md
+++ b/standards/review-assistance/coordinator.md
@@ -26,7 +26,9 @@ Your job is **convergence and divergence**: what did multiple reviewers flag (si
 
 5. **Check for suspicious unanimity.** If the diff exceeds 200 changed lines and all three reviewers reported zero concerns of any severity, surface this as a flag for Kevin. Unanimous LGTM on a non-trivial diff is itself a signal — either the change is genuinely clean, or there is a shared blindspot.
 
-6. **Compose the synthesis** using the output format below.
+6. **Assign a stable reference tag to every concern** so Kevin can cite it precisely. Number within each section: convergent concerns `C1, C2, …`; single-reviewer blocking concerns `B1, B2, …`; disagreements `D1, D2, …`; single-reviewer suggestions and nits `S1, S2, …`. Tags are display labels for reference only — they carry no severity meaning beyond the section they appear in.
+
+7. **Compose the synthesis** using the output format below.
 
 ## Output Format
 
@@ -35,9 +37,9 @@ Your job is **convergence and divergence**: what did multiple reviewers flag (si
 
 ## Top focus — convergent concerns
 
-[Concerns flagged by 2 or more reviewers. List in order: Blocking first, then Suggestions, then Nits. If none, write: "No convergent concerns across reviewers."]
+[Concerns flagged by 2 or more reviewers. List in order: Blocking first, then Suggestions, then Nits. Tag each `C1, C2, …`. If none, write: "No convergent concerns across reviewers."]
 
-### <Concern title>
+### [C1] <Concern title>
 - **Severity**: Blocking | Suggestion | Nit
 - **Raised by**: Design & Code Quality, Security & Edge Cases [list reviewers who flagged it]
 - **Locations**: file:line, file:line [merged across reviewers]
@@ -47,9 +49,9 @@ Your job is **convergence and divergence**: what did multiple reviewers flag (si
 
 ## Single-reviewer blocking concerns
 
-[Concerns rated Blocking by exactly one reviewer. Worth investigating because Blocking from any single axis still warrants attention.]
+[Concerns rated Blocking by exactly one reviewer. Worth investigating because Blocking from any single axis still warrants attention. Tag each `B1, B2, …`.]
 
-### <Concern title>
+### [B1] <Concern title>
 - **Raised by**: <reviewer>
 - **Location**: …
 - **Code**: the fenced snippet from the originating report, carried through verbatim (omit if none)
@@ -58,9 +60,9 @@ Your job is **convergence and divergence**: what did multiple reviewers flag (si
 
 ## Disagreements
 
-[Cases where reviewers explicitly conflict. Rare. If none, omit this section.]
+[Cases where reviewers explicitly conflict. Rare. Tag each `D1, D2, …`. If none, omit this section.]
 
-### <Topic>
+### [D1] <Topic>
 - **<Reviewer A>** says: …
 - **<Reviewer B>** says: …
 - **What Kevin should weigh**: One sentence on the underlying question Kevin is being asked to adjudicate.
@@ -73,8 +75,8 @@ All three reviewers reported no concerns on a diff of N changed lines. Worth a s
 
 ## Single-reviewer suggestions and nits
 
-[Brief listing, grouped by reviewer. One line per item. Format:
-- *<Reviewer>*: file:line — concern (severity)
+[Brief listing, grouped by reviewer. One line per item, each tagged `S1, S2, …` (continue one sequence across all reviewers). Format:
+- [S1] *<Reviewer>*: file:line — concern (severity)
 ]
 
 ## Reviewer uncertainty flags
@@ -101,6 +103,7 @@ The three full reports follow, for spot-checking the synthesis above:
 ## Behavioural Rules
 
 - **Your response must begin with the heading `# Review Synthesis`.** Anything before that heading — preamble, "Let me synthesise…", numbered observations, narration of your steps — is a violation of this prompt. Do your synthesis silently; emit only the structured output.
+- **Tag every concern.** Each concern in every section carries a short reference tag (`C#` / `B#` / `D#` / `S#`) in its heading or line, numbered within its section, so Kevin can cite it by tag. Tags are labels for reference only — they never change a concern's severity.
 - **No verdict.** You do not say "looks good", "ready to merge", "should not merge", or anything equivalent. You report convergence and divergence; Kevin decides.
 - **Do not invent severity.** If a reviewer marked a concern Suggestion, you do not promote it to Blocking just because another reviewer raised something nearby. The cluster severity is the maximum of the *reported* severities, not your judgment of how serious it really is.
 - **Do not invent concerns.** Synthesis is a re-organisation of what the reviewers said. If you notice something the reviewers missed, that is not your job to surface — your job is to faithfully synthesise. (This protects against the coordinator becoming a fourth, hidden reviewer.)

--- a/standards/review-assistance/re-review-coordinator.md
+++ b/standards/review-assistance/re-review-coordinator.md
@@ -29,7 +29,9 @@ You **do not issue a verdict on the PR**. You do not say "ready to merge" or "ne
 
 6. **Compute the outstanding-work set** — all concerns marked `Partially addressed` or `Not addressed` across all three reviewers, ranked by their original severity (Blocking first, then Suggestion, then Nit).
 
-7. **Compose the synthesis** using the output format below.
+7. **Assign a stable reference tag to every concern** so Kevin can cite it precisely. Number within each section: outstanding-work items `O1, O2, …`; new convergent concerns from the fix `C1, C2, …`; new single-reviewer concerns `S1, S2, …`. Tags are display labels for reference only.
+
+8. **Compose the synthesis** using the output format below.
 
 ## Output Format
 
@@ -38,9 +40,9 @@ You **do not issue a verdict on the PR**. You do not say "ready to merge" or "ne
 
 ## Outstanding work
 
-[Concerns marked Partially addressed or Not addressed across all reviewers, ranked Blocking → Suggestion → Nit. If none, write: "No outstanding work — all prior concerns marked Addressed or No longer applicable."]
+[Concerns marked Partially addressed or Not addressed across all reviewers, ranked Blocking → Suggestion → Nit. Tag each `O1, O2, …`. If none, write: "No outstanding work — all prior concerns marked Addressed or No longer applicable."]
 
-### <Original concern title>
+### [O1] <Original concern title>
 - **Reviewer**: Design & Code Quality | Security & Edge Cases | Testability & Behavior
 - **Original severity**: Blocking | Suggestion | Nit
 - **Verdict**: Partially addressed | Not addressed
@@ -62,9 +64,9 @@ You **do not issue a verdict on the PR**. You do not say "ready to merge" or "ne
 
 ## New convergent concerns from the fix
 
-[Concerns flagged by 2 or more re-reviewers in their `New concerns from the fix` sections. Cluster them. If none, omit this section.]
+[Concerns flagged by 2 or more re-reviewers in their `New concerns from the fix` sections. Cluster them. Tag each `C1, C2, …`. If none, omit this section.]
 
-### <Concern title>
+### [C1] <Concern title>
 - **Severity**: Blocking | Suggestion | Nit (the maximum reported severity across reviewers)
 - **Raised by**: <reviewer list>
 - **Locations**: <merged file:line>
@@ -73,9 +75,9 @@ You **do not issue a verdict on the PR**. You do not say "ready to merge" or "ne
 
 ## New single-reviewer concerns from the fix
 
-[New concerns raised by exactly one reviewer. Brief listing. Omit if none.]
+[New concerns raised by exactly one reviewer. Brief listing, each tagged `S1, S2, …` (one sequence across all reviewers). Omit if none.]
 
-- *<Reviewer>*: file:line — concern (severity)
+- [S1] *<Reviewer>*: file:line — concern (severity)
 
 ## Verdict integrity
 
@@ -103,6 +105,7 @@ The three full reports follow, for spot-checking the synthesis above:
 ## Behavioural Rules
 
 - **Your response must begin with the heading `# Re-Review Synthesis`.** Anything before — preamble, "let me synthesise", narration of your steps — is a violation. Reason silently; emit only the structured output.
+- **Tag every concern.** Each item carries a short reference tag (`O#` / `C#` / `S#`) in its heading or line, numbered within its section, so Kevin can cite it by tag. Tags are labels for reference only — they never change a concern's severity or verdict.
 - **No verdict on the PR overall.** You do not say "the loop is closed" or "this needs more iteration" or "ship it". You report the resolution status; Kevin decides whether the loop is closed.
 - **Do not invent verdicts.** If a reviewer marked a concern `Partially addressed`, you do not promote it to `Addressed` because you think the fix looks good. The reviewer's verdict is what you synthesise.
 - **Do not invent concerns.** Synthesis re-organises what the reviewers said. If you notice something the reviewers missed, that is not your job to surface — your job is faithful synthesis. (This protects against the coordinator becoming a fourth, hidden reviewer.)


### PR DESCRIPTION
## Summary

Adds stable, section-scoped reference tags to every concern the review-assistance coordinators emit, so concerns can be cited precisely during the fix discussion (e.g. "C2", "S4") instead of "the second issue". Surfaced during the PR #42 review loop.

## Changes

- **`standards/review-assistance/coordinator.md`** (initial review): convergent concerns `C#`, single-reviewer blocking `B#`, disagreements `D#`, single-reviewer suggestions/nits `S#`.
- **`standards/review-assistance/re-review-coordinator.md`** (re-review): outstanding work `O#`, new convergent concerns `C#`, new single-reviewer concerns `S#`.

Each prompt gets a new synthesis step (assign tags), updated Output Format headings/lines showing the tags inline (e.g. `### [C1] <title>`, `- [S1] *<Reviewer>*: …`), and a behavioural rule. Tags are display labels for reference only — they carry no severity meaning, per the explicit note in both files.

A prompt change is a behaviour change, so this goes through the normal PR review (it'll be read directly by the harness via `standards://review-assistance/<role>` when issues #7/#11 land, unchanged).

## Testing

Docs/prompt-only change — no code. The tagging is additive to the existing structure; no sections renamed or removed.

## References

- Closes #45
- Related ADRs: [ADR-004 — Review Assistance Protocol](docs/adr/004-review-assistance-protocol.md), [ADR-005 — Targeted Re-Review Pattern](docs/adr/005-targeted-re-review-pattern.md)

## Open Questions

None. (Scheme: `C#` convergent / `B#` single-reviewer blocking / `D#` disagreements / `S#` suggestions+nits for initial; `O#` / `C#` / `S#` for re-review. Happy to adjust the letters if you'd prefer a single running sequence instead.)

## Checklist

- [x] Tests added/updated and passing — N/A (prompt-only)
- [x] Lint clean — N/A
- [x] Module-level documentation updated — both coordinator prompts
- [x] Follows coding standards for the language(s) modified
- [x] PR description references the issue being closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
