### PR TITLE
docs(adr): mark ADR-006 accepted

### DIFF
--- a/docs/adr/006-tool-audit-hook-split.md
+++ b/docs/adr/006-tool-audit-hook-split.md
@@ -1,6 +1,6 @@
 # 006 — Where Tool-Call Audit Events Are Emitted
 
-**Status**: proposed
+**Status**: accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

One-line status correction: ADR-006 (two-hook tool audit emission) merged to main via PR #42 with status `proposed`. Per `docs/adr/README.md` — "`accepted` means merged to main" — it should read `accepted`.

## Changes

- `docs/adr/006-tool-audit-hook-split.md`: `**Status**: proposed` → `accepted`.

## Testing

Docs-only, single-line change.

## References

- Closes #47
- Related ADRs: [ADR-006](docs/adr/006-tool-audit-hook-split.md)
- Originated in PR #42 (issue #10)

## Open Questions

None.

## Checklist

- [x] Tests added/updated and passing — N/A (docs-only)
- [x] Lint clean — N/A
- [x] Module-level documentation updated — N/A
- [x] Follows coding standards for the language(s) modified
- [x] PR description references the issue being closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
